### PR TITLE
Make it possible to build using Nix.

### DIFF
--- a/examples/src/ConCat/SMT.hs
+++ b/examples/src/ConCat/SMT.hs
@@ -144,8 +144,10 @@ class EvalE a where
   evalE = (fmap.fmap) abst evalE
 
 evalEs :: EvalE a => Model -> [E] -> Z3 a
-evalEs model es = do (a,[]) <- runStateT (evalE model) es
-                     return a
+evalEs model es = do p <- runStateT (evalE model) es
+                     case p of
+                       (a, []) -> return a
+                       (_, st) -> error ("State is not empty: " ++ show st)
 
 -- type EvalAst m a = Model -> E -> m (Maybe a)
 
@@ -154,7 +156,7 @@ evalPrim ev f m =
   do es <- get
      case es of
        []      -> fail "evalPrim: exhausted ASTs"
-       (e:es') -> do Just a' <- lift (ev m e)
+       (e:es') -> do a' <- fmap (maybe (error "no value") id) (lift (ev m e))
                      put es'
                      return (f a')
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    buildInputs = [ pkgs.stack ];
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,10 @@
+nix:
+  packages:
+    - ghostscript
+    - graphviz
+    - imagemagick
+    - z3
+
 flags: {}
 packages:
   - inline
@@ -47,5 +54,5 @@ extra-deps:
 # resolver: lts-12.14 # ghc-8.4.3
 # resolver: lts-12.19 # ghc-8.4.4
 # resolver: lts-13.0 # ghc-8.6.3
-resolver: lts-13.13 # ghc-8.6.4
-# resolver: lts-14.6 # ghc-8.6.5
+# resolver: lts-13.13 # ghc-8.6.4
+resolver: lts-14.6 # ghc-8.6.5


### PR DESCRIPTION
- Add a shell.nix to make stack available,
- add nix packages to stack.yaml so the external deps are available if stack
  uses nix (which we should eventually pin) to build (a la
  https://docs.haskellstack.org/en/stable/nix_integration/),
- update the resolver, and
- fix a couple pattern matches in SMT.hs that relied on `MonadFail`.
